### PR TITLE
Fix list-view selection under-count on log axes

### DIFF
--- a/guidepost/src/guidepost/heatmap.js
+++ b/guidepost/src/guidepost/heatmap.js
@@ -143,6 +143,7 @@ class Heatmap{
                     .attr('transform', (d, i)=>`translate(${x_offset},${y_offset})`)
                     .attr('width', this.width)
                     .attr('height', this.height);
+        this.view = view;
 
 
         let axis_left = d3.axisLeft().scale(this.scale_y_inverse);
@@ -155,30 +156,7 @@ class Heatmap{
             .call(axis_left)   
             .attr('transform', `translate(${OVERVIEW_LAYOUT.inner_padding},${0})`);
 
-        if(this.x_is_band){
-            // Thin ticks so labels don't collide at high node cardinality, then
-            // rotate (≤45°) and truncate long names.
-            const domain = this.scale_x.domain();
-            const max_labels = 40;
-            const step = Math.max(1, Math.ceil(domain.length / max_labels));
-            const tick_vals = domain.filter((d, i) => i % step === 0);
-            view.append('g')
-                .attr('class', 'bottom-axis')
-                .call(d3.axisBottom(this.scale_x).tickValues(tick_vals))
-                .attr('transform', `translate(${0},${OVERVIEW_LAYOUT.height-OVERVIEW_LAYOUT.inner_padding})`)
-                .selectAll('text')
-                    .attr('text-anchor', 'start')
-                    .attr('transform', 'rotate(45)')
-                    .text(d => (typeof d === 'string' && d.length > MAX_NODE_LABEL_CHARS)
-                        ? d.slice(0, MAX_NODE_LABEL_CHARS) + '…'
-                        : d);
-        }
-        else{
-            view.append('g')
-                .attr('class', 'bottom-axis')
-                .call(d3.axisBottom().scale(this.scale_x.scale).ticks(this.scale_x.get_ticks()))
-                .attr('transform', `translate(${0},${OVERVIEW_LAYOUT.height-OVERVIEW_LAYOUT.inner_padding})`)
-        }
+        this.draw_x_axis();
 
         
         // Suppress the "Group:" title when faceting on the backend's synthetic
@@ -209,8 +187,38 @@ class Heatmap{
                 })
                 .attr('text-anchor', 'middle')
                 .attr('transform', `translate(${-10},${this.height/2}) rotate(270)`);
+    }
 
-        this.view = view;
+    /** Draws (or redraws) the bottom x-axis. Idempotent — selects the existing
+     *  `.bottom-axis` group or creates it — so it can be re-called on detail-zoom
+     *  re-renders to keep a grouped/list (band) x-axis in sync with the columns. */
+    draw_x_axis(){
+        let axis_g = this.view.select('.bottom-axis');
+        if(axis_g.empty()){
+            axis_g = this.view.append('g').attr('class', 'bottom-axis');
+        }
+        axis_g.attr('transform', `translate(${0},${OVERVIEW_LAYOUT.height-OVERVIEW_LAYOUT.inner_padding})`);
+
+        if(this.x_is_band){
+            // Thin ticks so labels don't collide at high node cardinality, then
+            // rotate (≤45°) and truncate long names.
+            const domain = this.scale_x.domain();
+            const max_labels = 40;
+            const step = Math.max(1, Math.ceil(domain.length / max_labels));
+            const tick_vals = domain.filter((d, i) => i % step === 0);
+            axis_g
+                .call(d3.axisBottom(this.scale_x).tickValues(tick_vals))
+                .selectAll('text')
+                    .attr('text-anchor', 'start')
+                    .attr('transform', 'rotate(45)')
+                    .text(d => (typeof d === 'string' && d.length > MAX_NODE_LABEL_CHARS)
+                        ? d.slice(0, MAX_NODE_LABEL_CHARS) + '…'
+                        : d);
+        }
+        else{
+            axis_g
+                .call(d3.axisBottom().scale(this.scale_x.scale).ticks(this.scale_x.get_ticks()));
+        }
     }
 
     /**
@@ -920,6 +928,7 @@ class Heatmap{
         this.model.detail_range[this.facet] = range;
         this._cols_cache = null;
         this.update_scales();
+        this.draw_x_axis();
         this.render();
     }
 
@@ -1535,21 +1544,30 @@ class Heatmap{
 
         if(this.x_is_band){
             const cr = ranges.col_range, yr = ranges.y_range;
+            const has_col = cr.length === 2, has_y = yr.length === 2;
+            // Neither axis constrained → no band selection (a cleared brush leaves
+            // both empty). Don't draw a phantom full box. A full-y brush has a
+            // non-empty col_range; a y-band histogram brush has a non-empty y_range.
+            if(!has_col && !has_y){ g.call(this.cell_brush.move, null); return; }
             const cols = this.current_columns();
             // Columns covered by col_range (empty col_range => all columns, e.g. a
             // y-only right-histogram brush spans the full x extent).
-            const covered = cr.length === 2
+            const covered = has_col
                 ? cols.filter(c => c.lo != null ? (c.lo <= cr[1] && c.hi >= cr[0])
                                                 : true)   // scalar: handled by index below
                 : cols;
-            const idxCovered = (cr.length === 2 && cols.length && cols[0].lo == null)
+            const idxCovered = (has_col && cols.length && cols[0].lo == null)
                 ? cols.filter((c, i) => i >= cr[0] && i <= cr[1])
                 : covered;
-            if(yr.length !== 2 || !idxCovered.length){ g.call(this.cell_brush.move, null); return; }
+            if(!idxCovered.length){ g.call(this.cell_brush.move, null); return; }
             const cw = this.col_width();
             const px0 = Math.min(...idxCovered.map(c => this.x_pos(c.threshold)));
             const px1 = Math.max(...idxCovered.map(c => this.x_pos(c.threshold))) + cw;
-            const py = [this.scale_y_blocks(yr[0]), this.scale_y_blocks(yr[1])];
+            // An empty y_range means "full y" (see on_cell_brush_end) — redraw a
+            // full-height box over the covered columns rather than clearing it.
+            const py = has_y
+                ? [this.scale_y_blocks(yr[0]), this.scale_y_blocks(yr[1])]
+                : [OVERVIEW_LAYOUT.inner_padding, OVERVIEW_LAYOUT.height - OVERVIEW_LAYOUT.inner_padding];
             g.call(this.cell_brush.move, [[px0, Math.min(...py)], [px1, Math.max(...py)]]);
             return;
         }
@@ -1604,9 +1622,21 @@ class Heatmap{
                 if(col.lo != null){ lo = Math.min(lo, col.lo); hi = Math.max(hi, col.hi); }
                 else { lo = Math.min(lo, ci); hi = Math.max(hi, ci); }
             }
+            // A band column's cells are a y-histogram; a job whose y falls outside
+            // the binned range (null, or below the log-scale floor) sits in NO cell.
+            // When the drag spans (within one row of) the full cell-area height the
+            // user means "these columns, all y", so drop the y restriction — an empty
+            // y_range routes _band_box_indices to col.indices (full membership),
+            // matching column-pin and the "(N records)" count. Pixel coverage is the
+            // robust signal (the mapped row-range rarely hits the exact edges). A
+            // partial-height drag keeps y_range and still restricts per-cell.
+            const full_y0 = OVERVIEW_LAYOUT.inner_padding;
+            const full_y1 = OVERVIEW_LAYOUT.height - OVERVIEW_LAYOUT.inner_padding;
+            const tol = this._cell_row_height(cols);   // one row of slack
+            const covers_full_y = (y0 <= full_y0 + tol) && (y1 >= full_y1 - tol);
             ranges.x_range = [];
             ranges.col_range = (lo !== Infinity) ? [lo, hi] : [];
-            ranges.y_range = y_range;
+            ranges.y_range = covers_full_y ? [] : y_range;
         } else {
             const xa = this.scale_x.scale.invert(x0);
             const xb = this.scale_x.scale.invert(x1);

--- a/guidepost/src/guidepost/js_model.js
+++ b/guidepost/src/guidepost/js_model.js
@@ -566,23 +566,27 @@ class JSModel{
     }
     
     /**
-     * Sanitizes data for log scale by replacing zero values with one.
+     * Sanitizes data for a log scale by clamping any value below the log floor
+     * up to the floor. A log axis starts at `log_values_floor`, so a value in
+     * [0, floor) can't be placed on it — binValues would drop it entirely (no
+     * bin matches `val < thresholds[0]`), silently losing real records (e.g.
+     * sub-1-Wh energy for standby/short jobs). Clamping puts them in bin 0 so
+     * cells, the right histogram, the count strip and brush/pin selection all
+     * agree. null/NaN are guarded (note `null < 1` is true in JS) so genuine
+     * missing values stay unbinned rather than masquerading as floor values.
      * @param {Array} data - The data to sanitize.
      * @param {string} col - The column to sanitize.
      * @returns {Array} - The sanitized data.
      */
     sanitize_data_for_log(data, col){
         data.forEach((element, i, arr) => {
-            //setting to 1 in this context is ok at
-            // the resolution of analysis we are doing
-            // diff 1 sec vs. 0 sec is functionally
-            // the same
-            if (element[col] == 0){
-                arr[i][col] = 1;
+            const v = element[col];
+            if (v != null && !Number.isNaN(v) && v < this.log_values_floor){
+                arr[i][col] = this.log_values_floor;
             }
         });
-    
-        return data; 
+
+        return data;
     }
 
     /**
@@ -2027,6 +2031,14 @@ class JSModel{
      * displayed cells whose column is in col_range (empty = all columns) and
      * whose row is in y_range (empty = all rows). Grouped columns carry
      * lo/hi (node-index overlap); scalar columns are matched by array index.
+     *
+     * A column's `bins` only hold rows with a non-null, in-range y value, so
+     * summing bin indices silently drops null/NaN-y rows — common for e.g.
+     * Failed jobs that never recorded a runtime metric. When the brush spans
+     * the FULL y extent (or sets no y restriction), the user is selecting whole
+     * columns, so use `col.indices` (the column's full membership) to match the
+     * displayed "(N records)" count and column-pin selection. A partial y-brush
+     * still restricts to the covered cells (null-y rows have no cell to brush).
      */
     _band_box_indices(facet){
         const cols = this.current_detail_columns(facet) || [];
@@ -2034,6 +2046,9 @@ class JSModel{
         const yr = this.brushed_ranges[facet].y_range;
         const has_col = cr.length === 2;
         const has_y = yr.length === 2;
+        // Rows are indexed 0..nbins-1; a full-height brush yields yr ≈ [nbins-1, -1].
+        const nbins = (cols[0] && cols[0].bins && cols[0].bins.length) || 0;
+        const y_covers_all = !has_y || (yr[1] <= 0 && yr[0] >= nbins - 1);
         const ids = new Set();
         for(let ci = 0; ci < cols.length; ci++){
             const col = cols[ci];
@@ -2045,8 +2060,14 @@ class JSModel{
                     : (ci >= cr[0] && ci <= cr[1]);          // scalar: column-index range
             }
             if(!in_col) continue;
+            if(y_covers_all){
+                // Whole column selected → full membership, including null-y rows.
+                const idx = col.indices;
+                if(idx) for(let i = 0; i < idx.length; i++) ids.add(idx[i]);
+                continue;
+            }
             for(let row = 0; row < col.bins.length; row++){
-                if(has_y && !(row >= yr[1] && row < yr[0])) continue;   // y_range is [hi, lo] descending
+                if(!(row >= yr[1] && row < yr[0])) continue;   // y_range is [hi, lo] descending
                 const idx = col.bins[row].indices;
                 if(!idx) continue;
                 for(let i = 0; i < idx.length; i++) ids.add(idx[i]);

--- a/tests/guidepost.test.js
+++ b/tests/guidepost.test.js
@@ -192,6 +192,18 @@ describe('JSModel — pure helpers', () => {
             model.sanitize_data_for_log(data, 'v');
             assert.deepStrictEqual(data.map(d => d.v), [1, 1, 5, 1]);
         });
+        it('clamps fractional sub-floor values up to the floor', () => {
+            const data = [{ v: 0.3 }, { v: 0.999 }, { v: 1 }, { v: 42 }];
+            model.sanitize_data_for_log(data, 'v');
+            assert.deepStrictEqual(data.map(d => d.v), [1, 1, 1, 42]);
+        });
+        it('leaves null / NaN untouched (not forced to the floor)', () => {
+            const data = [{ v: null }, { v: NaN }, { v: 0.5 }];
+            model.sanitize_data_for_log(data, 'v');
+            assert.strictEqual(data[0].v, null);
+            assert.ok(Number.isNaN(data[1].v));
+            assert.strictEqual(data[2].v, 1);   // sub-floor still clamped
+        });
     });
 
     describe('convert_to_date', () => {
@@ -357,6 +369,69 @@ describe('JSModel — constructor / sanitize pipeline', () => {
                 model.faceted_bins[fac].column.length
             );
         }
+    });
+});
+
+
+describe('JSModel — log y axis keeps sub-floor records in bin 0', () => {
+    // A log y axis floors at log_values_floor (1). Values in [0, 1) can't be
+    // placed on it; before the fix binValues dropped them, so cells / the right
+    // histogram / the per-cell brush undercounted vs the membership readouts
+    // (count strip, column-pin). sanitize_data_for_log now clamps them to the
+    // floor so every consumer agrees.
+    function catXLogY(withNull){
+        const gp_idx = {0:0,1:1,2:2,3:3,4:4,5:5};
+        const user   = {0:'u0',1:'u0',2:'u0',3:'u1',4:'u1',5:'u1'};
+        const y      = {0:0.3, 1:100, 2:10000, 3:1, 4:1000, 5:100000};   // spans >3 orders -> log
+        const color  = {0:1,1:2,2:3,3:4,4:5,5:6};
+        const cat    = {0:'a',1:'b',2:'a',3:'b',4:'a',5:'b'};
+        const fac    = {0:'A',1:'A',2:'A',3:'A',4:'A',5:'A'};
+        if(withNull){ gp_idx[6]=6; user[6]='u0'; y[6]=null; color[6]=7; cat[6]='a'; fac[6]='A'; }
+        const ss = { user:{ semantic_type:'categorical' } };
+        return { data:{gp_idx,user,y,color,cat,fac}, ss };
+    }
+    const CATX_VARS = { facet_by:'fac', x:'user', y:'y', color:'color', color_agg:'avg', categorical:'cat' };
+    const colByThreshold = (m, t) => m.faceted_bins.A.column.find(c => String(c.threshold) === t);
+
+    it('uses a log y scale and clamps the sub-floor record into bin 0', () => {
+        const { data, ss } = catXLogY(false);
+        const m = new JSModel(data, CATX_VARS, ss, makeAnywidgetStub());
+        assert.strictEqual(m.scale_types.A.y.log, true);
+        const u0 = colByThreshold(m, 'u0');
+        // gp_idx 0 (y=0.3, sub-floor) is now binned into the bottom row, not dropped.
+        assert.ok(Array.from(u0.bins[0].indices).includes(0), 'sub-floor record must land in bin 0');
+    });
+
+    it('cells retain every record — bin sum equals column membership', () => {
+        const { data, ss } = catXLogY(false);
+        const m = new JSModel(data, CATX_VARS, ss, makeAnywidgetStub());
+        for(const col of m.faceted_bins.A.column){
+            const binned = col.bins.reduce((a, b) => a + b.count, 0);
+            assert.strictEqual(binned, col.count, `column ${col.threshold} must drop no records`);
+        }
+        // Right histogram (row_major_counts) now sums to the full record count.
+        assert.strictEqual(m.row_major_counts.A.reduce((a, b) => a + b, 0), 6);
+    });
+
+    it('a partial bottom band brush selects the sub-floor record', async () => {
+        const { data, ss } = catXLogY(false);
+        const stub = makeAnywidgetStub();
+        const m = new JSModel(data, CATX_VARS, ss, stub);
+        m.brushed_ranges.A.col_range = [];
+        m.brushed_ranges.A.y_range = [1, -1];   // bottom row only (partial y)
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']);
+        assert.ok(sel.includes(0), 'sub-floor record sits in the bottom cell and must be brushable');
+    });
+
+    it('genuine null-y records stay out of cells (only membership counts them)', () => {
+        const { data, ss } = catXLogY(true);
+        const m = new JSModel(data, CATX_VARS, ss, makeAnywidgetStub());
+        const u0 = colByThreshold(m, 'u0');
+        assert.strictEqual(u0.count, 4);   // membership: gp_idx 0,1,2,6
+        assert.strictEqual(u0.bins.reduce((a, b) => a + b.count, 0), 3);   // null (6) not binned
+        const inBins = u0.bins.some(b => Array.from(b.indices).includes(6));
+        assert.ok(!inBins, 'null-y record must not appear in any cell');
     });
 });
 
@@ -1434,5 +1509,97 @@ describe('JSModel — band box brush (2-d ↔ histogram via shared ranges)', () 
         m.set_pin_indices('A', [4], []);          // pin adds record 4
         const sel = JSON.parse(stub._state['selected_records']).sort((a,b)=>a-b);
         assert.deepStrictEqual(sel, [1, 4]);
+    });
+
+    // A scalar categorical x with null-y rows: those rows have no cell (they
+    // fall in no y-bin), but they DO belong to the column. A full-height brush
+    // must select them (match the displayed column count); a partial y-brush
+    // legitimately excludes them.
+    function scalarWithNullY(){
+        // user 'u0' has 3 records, one with null y; 'u1' has 2, all with y.
+        const gp_idx = {0:0,1:1,2:2,3:3,4:4};
+        const user   = {0:'u0',1:'u0',2:'u0',3:'u1',4:'u1'};
+        const y      = {0:1,   1:9,   2:null,3:1,   4:9};
+        const color  = {0:1,   1:2,   2:3,   3:4,   4:5};
+        const cat    = {0:'r', 1:'g', 2:'b', 3:'r', 4:'g'};
+        const fac    = {0:'A', 1:'A', 2:'A', 3:'A', 4:'A'};
+        const ss = { user:{ semantic_type:'categorical' } };
+        return { data:{gp_idx,user,y,color,cat,fac}, ss };
+    }
+    const SCALAR_VARS = { facet_by:'fac', x:'user', y:'y', color:'color', color_agg:'avg', categorical:'cat' };
+
+    it('a full-height band brush includes null-y rows (matches the column count)', async () => {
+        const stub = makeAnywidgetStub();
+        const { data, ss } = scalarWithNullY();
+        const m = new JSModel(data, SCALAR_VARS, ss, stub);
+        m.brushed_ranges.A.col_range = [];       // all columns
+        m.brushed_ranges.A.y_range = [50, -1];   // full y extent
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']).sort((a,b)=>a-b);
+        assert.deepStrictEqual(sel, [0, 1, 2, 3, 4]);   // incl. record 2 (null y)
+    });
+
+    it('a partial y-brush still excludes null-y rows (no cell to brush)', async () => {
+        const stub = makeAnywidgetStub();
+        const { data, ss } = scalarWithNullY();
+        const m = new JSModel(data, SCALAR_VARS, ss, stub);
+        const nbins = m.current_detail_columns('A')[0].bins.length;
+        m.brushed_ranges.A.col_range = [];
+        m.brushed_ranges.A.y_range = [Math.floor(nbins/2), -1];   // lower half only
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']);
+        assert.ok(!sel.includes(2), 'null-y record must not appear in a partial y-brush');
+    });
+
+    // Grouped LIST x (the reported bug): a job whose y is null OR below the log
+    // floor lands in no cell but IS in the column's membership. Record gp_idx=5
+    // has null y on node n0 — in col.indices but in no col.bins[row].indices. A
+    // full-height band drag (represented as an empty y_range by on_cell_brush_end)
+    // must select it; a partial y-brush must not.
+    function groupedWithOutOfCellRow(){
+        const nodes = {0:['x1000c0s0b0n0'],1:['x1000c0s0b0n1'],2:['x1000c0s1b0n0'],3:['x1000c0s1b0n1'],4:['x1000c0s0b0n0']};
+        const gp_idx = {0:1,1:2,2:3,3:4,4:5}, y = {0:1,1:9,2:1,3:9,4:null}, color = {0:1,1:2,2:3,3:4,4:2};
+        const cat = {0:'r',1:'g',2:'b',3:'r',4:'g'}, fac = {0:'A',1:'A',2:'A',3:'A',4:'A'};
+        const order = ['x1000c0s0b0n0','x1000c0s0b0n1','x1000c0s1b0n0','x1000c0s1b0n1'];
+        const mk = n => ['x1000','x1000c0',n.slice(0,9),n.slice(0,11),n];
+        const hierarchy = Object.fromEntries(order.map(n => [n, mk(n)]));
+        const ss = { nodes:{ semantic_type:'categorical', is_list:true,
+            category_order:order, category_hierarchy:hierarchy,
+            category_levels:['cabinet','chassis','slot','blade'] } };
+        return { data:{gp_idx,nodes,y,color,cat,fac}, ss };
+    }
+
+    it('full-height grouped list-x brush (empty y_range) includes out-of-cell rows', async () => {
+        const stub = makeAnywidgetStub();
+        const { data, ss } = groupedWithOutOfCellRow();
+        const m = new JSModel(data, VARS, ss, stub);
+        m.brushed_ranges.A.col_range = [0, 3];   // all four nodes
+        m.brushed_ranges.A.y_range = [];         // full y (on_cell_brush_end sentinel)
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']).sort((a,b)=>a-b);
+        assert.deepStrictEqual(sel, [1, 2, 3, 4, 5]);   // incl. record 5 (null y)
+    });
+
+    it('numeric full y-band (histogram path) includes out-of-cell rows', async () => {
+        const stub = makeAnywidgetStub();
+        const { data, ss } = groupedWithOutOfCellRow();
+        const m = new JSModel(data, VARS, ss, stub);
+        m.brushed_ranges.A.col_range = [];       // all columns (y-only brush)
+        m.brushed_ranges.A.y_range = [50, -1];   // full y band (numeric)
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']).sort((a,b)=>a-b);
+        assert.deepStrictEqual(sel, [1, 2, 3, 4, 5]);
+    });
+
+    it('partial y-brush excludes out-of-cell rows for a grouped list x', async () => {
+        const stub = makeAnywidgetStub();
+        const { data, ss } = groupedWithOutOfCellRow();
+        const m = new JSModel(data, VARS, ss, stub);
+        const nbins = m.current_detail_columns('A')[0].bins.length;
+        m.brushed_ranges.A.col_range = [0, 3];
+        m.brushed_ranges.A.y_range = [Math.floor(nbins/2), -1];   // lower half only
+        await m._apply_brush_selection('A', [], false);
+        const sel = JSON.parse(stub._state['selected_records']);
+        assert.ok(!sel.includes(5), 'out-of-cell (null-y) record must not appear in a partial y-brush');
     });
 });


### PR DESCRIPTION
## Summary

Fixes a selection under-count bug on log-scaled y-axes. On a log axis (floor = `log_values_floor`, e.g. 1), heatmap cells silently dropped every record with `0 < y < 1`: `sanitize_data_for_log` only promoted exact zeros, so `binValues` found no bin for sub-floor values and excluded them. This made cell-based readouts (right histogram, per-cell 2D brush) under-count by up to ~70× versus membership-based readouts (the "(N records)" count strip/tooltip and column-pin) — e.g. a column showing ~7040 records whose cells summed to ~100.

## Changes

- **`sanitize_data_for_log`** now clamps any value in `[0, floor)` up to the floor (guarding `null`/`NaN`, since `null < 1` is truthy in JS) so sub-floor records land in bin 0. Every consumer — count strip, right histogram, column-pin, and brush — now agrees. Log-axis-only; export is unaffected (Python re-fetches originals by `gp_idx`).
- **Band 2D-brush**: a full-height drag is detected by pixel coverage and selects full column membership (`col.indices`) so it matches column-pin exactly, including the handful of true-null-y records that have no cell. `reflect_cell_brush` redraws the full-height box accordingly.
- Extracted x-axis rendering into an idempotent `draw_x_axis()` so a grouped/list (band) x-axis stays in sync with columns on detail-zoom re-renders.

## Testing

Adds mocha coverage for the floor-clamp, sub-floor binning/consistency, and full/partial band-brush selection. **113 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)