### PR TITLE
Add sort_by override for list-column x-axis ordering

### DIFF
--- a/guidepost/guidepost.py
+++ b/guidepost/guidepost.py
@@ -77,6 +77,16 @@ class Guidepost(anywidget.AnyWidget):
         # identifiers the name heuristic misses, or to override an unwanted
         # auto-classification. Mirrors list_columns; pulled before super().
         categorical_columns = kwargs.pop("categorical_columns", None)
+        # Optional override for list-column x-axis ordering, replacing the
+        # built-in node-layout / seriation heuristics — for ordinal-but-not-
+        # hierarchical values the heuristics can't order (e.g. nodes named
+        # "1","2","3"). Either a single callable applied to every list column,
+        # or a {column: callable} dict for per-column control. Each callable is
+        # a full-list transform: it receives the list of distinct category
+        # values and returns them reordered. A callable can't be JSON-synced,
+        # so like list_columns this is a plain Python attribute (not a trait);
+        # it runs in load_data and only its *result* ships to the frontend.
+        sort_by = kwargs.pop("sort_by", None)
         super().__init__(*args, **kwargs)
         self._categorical_columns = set(categorical_columns) if categorical_columns else set()
         self._list_columns = list(list_columns) if list_columns else []
@@ -85,6 +95,20 @@ class Guidepost(anywidget.AnyWidget):
         # before the first load don't fail.
         self._effective_list_columns = list(self._list_columns)
         self._list_delimiter = list_delimiter or ","
+        # Validate up front so a bad sort_by fails at construction, not silently
+        # at render. None | callable | {str: callable} are the only valid shapes.
+        if sort_by is not None:
+            if isinstance(sort_by, dict):
+                bad = [k for k, v in sort_by.items() if not callable(v)]
+                if bad:
+                    raise TypeError(
+                        "sort_by dict values must be callables; non-callable "
+                        f"value(s) for column(s): {bad}")
+            elif not callable(sort_by):
+                raise TypeError(
+                    "sort_by must be a callable or a {column: callable} dict, "
+                    f"got {type(sort_by).__name__}")
+        self._sort_by = sort_by
         # DuckDB-backed aggregator. Lazily created when the first DataFrame
         # is loaded — keeping it None until then so widgets constructed
         # without data don't pay the import/registration cost.
@@ -194,7 +218,8 @@ class Guidepost(anywidget.AnyWidget):
         # that retains every node); arbitrary categories fall back to spectral
         # seriation (ships `category_score` for the column cap). Both share
         # `category_order` for the kept/ordered sequence.
-        ordering = compute_category_ordering(o_df, self._effective_list_columns)
+        ordering = compute_category_ordering(
+            o_df, self._effective_list_columns, sort_overrides=self._sort_by)
         for col, info in ordering.items():
             if col not in summary_stats:
                 continue

--- a/guidepost/seriation.py
+++ b/guidepost/seriation.py
@@ -15,23 +15,63 @@ Both derive from the same node x node co-occurrence matrix. sklearn/scipy are
 imported lazily so the cost is only paid when a list column is present.
 """
 
+import warnings
+
 import numpy as np
 
 from .node_layout import compute_node_layout
 
 
-def compute_category_ordering(o_df, list_columns):
-    """Dispatch ordering per list column: prefer structure-aware node-name
-    layout, fall back to spectral co-occurrence seriation.
+def _resolve_override(sort_overrides, col):
+    """Resolve the user sort override applicable to *col*, if any. A bare
+    callable applies to every column; a dict maps column name -> callable."""
+    if sort_overrides is None:
+        return None
+    if callable(sort_overrides):
+        return sort_overrides
+    if isinstance(sort_overrides, dict):
+        return sort_overrides.get(col)
+    return None
 
-    Returns ``{col: info}`` where *info* is either the structured shape
-    ``{"order", "hierarchy", "levels"}`` (node names follow a hardware-layout
-    convention) or the seriation shape ``{"order", "score"}`` (arbitrary
-    categories). The frontend treats both uniformly via ``category_order`` and
-    branches on the presence of ``category_hierarchy``.
+
+def _apply_override(fn, names):
+    """Run a user override (full-list transform) over the distinct category
+    names, coercing the result to the String() keys the frontend uses. Raises
+    on a non-iterable return so the caller can fall back to the heuristics."""
+    ordered = fn(list(names))
+    return [str(k) for k in ordered]
+
+
+def compute_category_ordering(o_df, list_columns, sort_overrides=None):
+    """Dispatch ordering per list column: a user override (if provided) wins,
+    else prefer structure-aware node-name layout, else fall back to spectral
+    co-occurrence seriation.
+
+    Returns ``{col: info}`` where *info* is one of:
+    - ``{"order"}`` — a user ``sort_overrides`` transform for this column,
+    - ``{"order", "hierarchy", "levels"}`` — node names follow a hardware-layout
+      convention, or
+    - ``{"order", "score"}`` — arbitrary categories (seriation).
+    The frontend treats all three uniformly via ``category_order`` and branches
+    on the presence of ``category_hierarchy``.
+
+    *sort_overrides* is ``None``, a single callable applied to every list
+    column, or a ``{column: callable}`` dict. Each callable receives the list
+    of distinct category values and returns them reordered. A callable that
+    raises (or returns a non-iterable) falls back to the heuristics for that
+    column with a warning, so a bad override never aborts data loading.
     """
     if not list_columns:
         return {}
+
+    # Warn on dict keys that don't name a list column (typo / out of scope):
+    # they'd otherwise be silently ignored.
+    if isinstance(sort_overrides, dict):
+        unknown = [c for c in sort_overrides if c not in list_columns]
+        if unknown:
+            warnings.warn(
+                "sort_by names column(s) that are not list columns and will be "
+                f"ignored: {unknown}. Custom sort applies to list columns only.")
 
     out = {}
     fallback_cols = []
@@ -39,7 +79,20 @@ def compute_category_ordering(o_df, list_columns):
         if col not in o_df.columns:
             continue
         names = _distinct_node_names(o_df[col])
-        layout = compute_node_layout(names) if names else None
+        if not names:
+            continue
+
+        override = _resolve_override(sort_overrides, col)
+        if override is not None:
+            try:
+                out[col] = {"order": _apply_override(override, names)}
+                continue
+            except Exception as exc:  # noqa: BLE001 - fall back, never abort load
+                warnings.warn(
+                    f"sort_by override for column '{col}' raised {exc!r}; "
+                    "falling back to the default ordering heuristic.")
+
+        layout = compute_node_layout(names)
         if layout is not None:
             out[col] = layout
         else:

--- a/tests/test_custom_sort.py
+++ b/tests/test_custom_sort.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for the ``sort_by`` custom x-axis ordering override
+(``guidepost.seriation.compute_category_ordering`` + the Guidepost
+constructor). Run via:
+
+    pytest tests/test_custom_sort.py -v
+
+Covers the motivating case: list data that is ordinal but NOT hierarchical
+(nodes named "1","2",...,"12"), which the built-in node-layout / seriation
+heuristics can't order sensibly. A user-supplied full-list transform replaces
+them and its result flows through the existing ``category_order`` channel.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from guidepost import Guidepost
+from guidepost.seriation import compute_category_ordering
+
+
+def _df(cells, col="nodes"):
+    """A one-list-column frame whose cells are already-parsed Python lists."""
+    return pd.DataFrame({col: list(cells)})
+
+
+# Numeric-named nodes: string sort gives "1","10","11",... — the override fixes it.
+NUMERIC_CELLS = [[str(n)] for n in range(1, 13)]          # "1".."12"
+NUMERIC_EXPECTED = [str(n) for n in range(1, 13)]
+
+# Cray-convention names → default heuristic yields a node-name hierarchy.
+CRAY_CELLS = [["x1008c0s0b0n0"], ["x1008c0s0b0n1"], ["x1008c0s0b1n0"]]
+
+
+def _numeric_sort(cats):
+    return sorted(cats, key=int)
+
+
+# ----- override wins, produces a bare {"order"} entry -----
+
+def test_dict_override_numeric_order():
+    ordering = compute_category_ordering(
+        _df(NUMERIC_CELLS), ["nodes"], sort_overrides={"nodes": _numeric_sort})
+    info = ordering["nodes"]
+    assert info["order"] == NUMERIC_EXPECTED
+    # Override short-circuits the heuristics: no hierarchy / score shipped.
+    assert "category_hierarchy" not in info and "hierarchy" not in info
+    assert "score" not in info
+
+
+def test_bare_callable_applies_to_all_list_columns():
+    df = pd.DataFrame({"nodes": NUMERIC_CELLS, "racks": [[c[0]] for c in NUMERIC_CELLS]})
+    ordering = compute_category_ordering(
+        df, ["nodes", "racks"], sort_overrides=_numeric_sort)
+    assert ordering["nodes"]["order"] == NUMERIC_EXPECTED
+    assert ordering["racks"]["order"] == NUMERIC_EXPECTED
+
+
+def test_dict_targets_one_column_other_keeps_default():
+    # nodes -> override; racks -> default heuristic (Cray hierarchy). Both
+    # columns must share a length; cycle the Cray names to match nodes.
+    racks = [CRAY_CELLS[i % len(CRAY_CELLS)] for i in range(len(NUMERIC_CELLS))]
+    df = pd.DataFrame({"nodes": NUMERIC_CELLS, "racks": racks})
+    ordering = compute_category_ordering(
+        df, ["nodes", "racks"], sort_overrides={"nodes": _numeric_sort})
+    assert ordering["nodes"]["order"] == NUMERIC_EXPECTED
+    assert "hierarchy" not in ordering["nodes"]
+    # Untouched column ran a heuristic → carries a heuristic-only shape.
+    racks = ordering["racks"]
+    assert "order" in racks and ("hierarchy" in racks or "score" in racks)
+
+
+def test_result_is_stringified_to_match_js_keys():
+    # An override that returns ints must be coerced back to the String() keys
+    # the frontend builds columns from.
+    ordering = compute_category_ordering(
+        _df(NUMERIC_CELLS), ["nodes"], sort_overrides=lambda c: sorted(c, key=int))
+    assert all(isinstance(k, str) for k in ordering["nodes"]["order"])
+
+
+# ----- robustness: a bad override never aborts loading -----
+
+def test_raising_override_falls_back_with_warning():
+    # int() on non-numeric names raises → fall back to the heuristic, don't abort.
+    df = _df(CRAY_CELLS)
+    with pytest.warns(UserWarning, match="falling back"):
+        ordering = compute_category_ordering(
+            df, ["nodes"], sort_overrides=_numeric_sort)
+    info = ordering["nodes"]
+    assert "order" in info
+    # Fell back to the node-layout heuristic (hierarchy present), not the override.
+    assert "hierarchy" in info
+
+
+def test_unknown_dict_key_warns():
+    with pytest.warns(UserWarning, match="not list columns"):
+        compute_category_ordering(
+            _df(NUMERIC_CELLS), ["nodes"],
+            sort_overrides={"nodes": _numeric_sort, "typo_col": _numeric_sort})
+
+
+def test_partial_order_kept_verbatim():
+    # An override may drop values; the Python order is the subset as-returned
+    # (the frontend's _ordered_nodes appends any present-but-omitted keys).
+    subset = lambda c: [x for x in sorted(c, key=int) if int(x) <= 3]
+    ordering = compute_category_ordering(
+        _df(NUMERIC_CELLS), ["nodes"], sort_overrides={"nodes": subset})
+    assert ordering["nodes"]["order"] == ["1", "2", "3"]
+
+
+# ----- constructor validation -----
+
+def test_constructor_rejects_non_callable():
+    with pytest.raises(TypeError):
+        Guidepost(list_columns=["nodes"], sort_by=123)
+
+
+def test_constructor_rejects_dict_with_non_callable_value():
+    with pytest.raises(TypeError):
+        Guidepost(list_columns=["nodes"], sort_by={"nodes": "not callable"})
+
+
+def test_constructor_accepts_callable_and_dict():
+    Guidepost(list_columns=["nodes"], sort_by=_numeric_sort)
+    Guidepost(list_columns=["nodes"], sort_by={"nodes": _numeric_sort})
+
+
+# ----- end-to-end: sort_by reaches _summary_stats via load_data -----
+
+def test_load_data_wires_sort_by_into_summary_stats():
+    rng = np.arange(24)
+    df = pd.DataFrame({
+        "nodes": [[str((i % 12) + 1)] for i in rng],   # numeric-named node list
+        "runtime": rng.astype(float),
+        "power": (rng * 2).astype(float),
+        "energy": (rng * 3).astype(float),
+        "queue": ["short" if i % 2 else "long" for i in rng],
+    })
+    gp = Guidepost(list_columns=["nodes"], sort_by={"nodes": _numeric_sort})
+    gp.suppress_warnings = True
+    gp.load_data(df)
+    stats = gp._summary_stats["nodes"]
+    assert stats["category_order"] == NUMERIC_EXPECTED
+    assert "category_hierarchy" not in stats and "category_score" not in stats


### PR DESCRIPTION
## Summary

Adds a `sort_by` constructor argument that lets callers override Guidepost's built-in x-axis ordering heuristics for list columns.

The built-in heuristics (structure-aware node-name layout, then spectral co-occurrence seriation) can't sensibly order list data that is **ordinal but not hierarchical** — e.g. nodes named `"1"`, `"2"`, …, `"12"`. Those fail the `alpha+digit` node-name parse and fall through to seriation, producing a non-numeric axis order (`1, 10, 11, 12, 2, …`) with no way to correct it.

## API

```python
# Single callable — applied to every list column
Guidepost(list_columns=['nodes'], sort_by=lambda cats: sorted(cats, key=int))

# Per-column dict
Guidepost(list_columns=['nodes', 'racks'], sort_by={'nodes': lambda c: sorted(c, key=int)})
```

Each callable is a **full-list transform**: it receives the list of distinct category values and returns them reordered.

## How it works

- The override runs **in Python at load time** and writes its result into the existing `category_order` channel on `_summary_stats` — so no lambda is ever serialized to JS and **no frontend change is required** (list columns already consume `category_order` via `_ordered_nodes`).
- An override **short-circuits** node-layout and seriation for its column (ships only `category_order`, no `category_hierarchy`/`category_score`); the frontend's grouping falls back to fixed-size chunks over the user's order.
- **Robustness:** a raising override (e.g. `int("abc")` on a mixed column) falls back to the default heuristic with a warning rather than aborting `load_data`. Unknown dict keys warn. Constructor validates the argument shape up front (`TypeError` otherwise).

## Scope

List columns only. Scalar categorical x-axes remain frequency-ranked + capped, unchanged.

## Testing

- New `tests/test_custom_sort.py` (11 cases): numeric override, bare-callable vs per-column dict, str coercion, raising-override fallback, unknown-key warning, partial order, constructor validation, end-to-end `load_data`.
- Full suite green: **64 Python tests pass**, **102 mocha pass** (JS untouched).
- Smoke test confirms `1, 10, 11, 12, 2, …` → `1, 2, …, 12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)